### PR TITLE
installation: add missing header to installation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,8 @@ headers = ['attr_kind.pxd',
            'ir.pxd',
            'pyllco.pxd',
            'pyllco_helper.h',
-           'pyllco_helper.pxd']
+           'pyllco_helper.pxd',
+           'adt.pxd']
 
 # step 3
 pyllco_pyx_cpp = custom_target('pyllco',


### PR DESCRIPTION
without this header the installed version of pyllco is not usable